### PR TITLE
FIX cors.io API change

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = function (username, cb) {
 
   // oh yeah //extreme fragility//
   if (process.browser) {
-    url = 'https://cors.io/?u=' + url
+    url = 'http://cors.io/?' + url
   }
 
   request(url, function (err, res, body) {


### PR DESCRIPTION
https://cors.io refuses to connect. API had also changed dropping the **u=** and no longer accepting it if it is passed.
