### PR TITLE
bugfix for fullname text when it is a single emoji

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,11 +30,12 @@ module.exports = function (username, cb) {
         }
         var header = xpath.select('./div[contains(@class, \'stream-item-header\')]', tweet)[0]
         var body = xpath.select('*/p[contains(@class, \'tweet-text\')]/text()', tweet)[0]
+        var fullname = xpath.select('./a/strong[contains(@class, "fullname")]/text()', header)[0]
         if (body) body = nodeToText(body)
         var item = {
           username: '@' + xpath.select('./a/span[contains(@class, \'username\')]/b/text()', header)[0].data,
           body: body,
-          fullname: xpath.select('./a/strong[contains(@class, "fullname")]/text()', header)[0].data,
+          fullname: fullname ? fullname.data : '',
           avatar: xpath.select('./a/img[contains(@class, "avatar")]/@src', header)[0].value,
           url: 'https://twitter.com' + xpath.select('./small[contains(@class, "time")]/a[contains(@class, "tweet-timestamp")]/@href', header)[0].value,
           timestamp: xpath.select('./small[contains(@class, "time")]/a[contains(@class, "tweet-timestamp")]/span/@data-time', header)[0].value


### PR DESCRIPTION
Came across this interesting corner case where a users' fullname text was just one single emoji, which caused latest-tweets to error because twitter is displaying emoji in two separate child spans within `'.fullname'` nodes (one span that uses background image to diplay emoji, one span that is hidden that contains the actual emoji character).

For my use case, am not doing much with fullname and would like this module to just not error out when it hits the fullname node, so the fix I'm including in this PR is very simple.

If you want to do something more robust I'll leave that to your judgement, along with a couple of screenshot examples of Twitter accounts. The first screenshot is the single emoji case that causes an error. The second one does not cause an error because the fullname also includes plaintext which is returned without error (but also omits the emoji from the fullname).

Would be great to get this quick fix merged so as to at least not error out.

![screen shot 2017-01-04 at 3 46 19 pm](https://cloud.githubusercontent.com/assets/1278969/21664521/e160669c-d29b-11e6-9dd3-56128947fbfa.png)

![screen shot 2017-01-04 at 4 31 52 pm](https://cloud.githubusercontent.com/assets/1278969/21664530/f119a670-d29b-11e6-8b6f-f59e2bf974cc.png)

